### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm i && npm run play"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![snekjs on NPM](https://img.shields.io/npm/v/snekjs.svg?color=green&label=snekjs)](https://www.npmjs.com/package/snekjs)
 
+[![Run on Repl.it](https://repl.it/badge/github/taniarascia/snek)](https://repl.it/github/taniarascia/snek)
+
 A terminal-based Snake implementation written in JavaScript (Node.js).
 
 ### [Read the tutorial](https://www.taniarascia.com/snake-game-in-javascript/)


### PR DESCRIPTION
It'd be fun to be able to play this in-browser through repl.it!

![Capture](https://user-images.githubusercontent.com/39810066/70534672-84922200-1b29-11ea-82ce-d3be52fb5cf5.PNG)

_"This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/snek-1)."_